### PR TITLE
Adjusted Header settings for Layout 1 - Layout 5  and moved the speci…

### DIFF
--- a/Configuration/PageTS/Library/tceform.pagets
+++ b/Configuration/PageTS/Library/tceform.pagets
@@ -1,23 +1,238 @@
-## Rename Layout-types
-//TCEFORM.tt_content.header_layout.altLabels {
-//    1 = H1 (primary font)
-//    2 = H2 (primary font)
-//    3 = H3 (primary font)
-//	  4 = H4 (primary font)
-//	  5 = H5 (primary font)
-//}
 TCEFORM.tt_content.header_layout.addItems {
-    6 = H2 Block Header
-    7 = H2 Block Header Row
-    8 = Horizontal Line - No Header Text
-    1000 = ---
-    1001 = H1 Title fadeInDown
-    1002 = H1 Title fadeInUp
-    1003 = H1 Title slideInLeft
-    1004 = H1 Title slideInRight
-    2000 = ---
-    2001 = H2 Block Header
-    2002 = H2 Block Header Row
+
+    h1a-AttentionSeekers = -- Attention Seekers --
+
+    h1a-bounce = H1 Title bounce
+    h1a-flash = H1 Title flash
+    h1a-pulse = H1 Title pulse
+    h1a-rubberBand = H1 Title rubberBand
+    h1a-shake = H1 Title shake
+    h1a-swing = H1 Title swing
+    h1a-tada = H1 Title tada
+    h1a-wobble = H1 Title wobble
+    h1a-jello = H1 Title jello
+
+    h1a-BouncingEntrances = -- Bouncing Entrances --
+
+    h1a-bounceIn = H1 Title bounceIn
+    h1a-bounceInDown = H1 Title bounceInDown
+	h1a-bounceInLeft = H1 Title bounceInLeft
+	h1a-bounceInRight = H1 Title bounceInRight
+	h1a-bounceInUp = H1 Title bounceInUp
+
+	h1a-BouncingExits = -- Bouncing Exits
+
+	h1a-bounceOut = H1 Title bounceOut
+	h1a-bounceOutDown = H1 Title bounceOutDown
+	h1a-bounceOutLeft = H1 Title bounceOutLeft
+	h1a-bounceOutRight = H1 Title bounceOutRight
+	h1a-bounceOutUp = H1 Title bounceOutUp
+
+	h1a-FadingEntrances = -- Fading Entrances --
+
+	h1a-fadeIn = H1 Title fadeIn
+	h1a-fadeInDown = H1 Title fadeInDown
+	h1a-fadeInDownBig = H1 Title fadeInDownBig
+	h1a-fadeInLeft = H1 Title fadeInLeft
+	h1a-fadeInLeftBig = H1 Title fadeInLeftBig
+	h1a-fadeInRight = H1 Title fadeInRight
+	h1a-fadeInRightBig = H1 Title fadeInRightBig
+	h1a-fadeInUp = H1 Title fadeInUp
+	h1a-fadeInUpBig = H1 Title fadeInUpBig
+
+	h1a-FadingExits = -- Fading Exits --
+
+	h1a-fadeOut = H1 Title fadeOut
+	h1a-fadeOutDown = H1 Title fadeOutDown
+	h1a-fadeOutDownBig = H1 Title fadeOutDownBig
+	h1a-fadeOutLeft = H1 Title fadeOutLeft
+	h1a-fadeOutLeftBig = H1 Title fadeOutLeftBig
+	h1a-fadeOutRight = H1 Title fadeOutRight
+	h1a-fadeOutRightBig = H1 Title fadeOutRightBig
+	h1a-fadeOutUp = H1 Title fadeOutUp
+	h1a-fadeOutUpBig = H1 Title fadeOutUpBig
+
+	h1a-Flippers = -- Flippers --
+
+	h1a-flip = H1 Title flip
+	h1a-flipInX = H1 Title flipInX
+	h1a-flipInY = H1 Title flipInY
+	h1a-flipOutX = H1 Title flipOutX
+	h1a-flipOutY = H1 Title flipOutY
+
+	h1a-Lightspeed = -- Lightspeed --
+
+	h1a-lightSpeedIn = H1 Title lightSpeedIn
+	h1a-lightSpeedOut = H1 Title lightSpeedOut
+
+	h1a-RotatingEntrances = -- Rotating Entrances --
+
+	h1a-rotateIn = H1 Title rotateIn
+	h1a-rotateInDownLeft = H1 Title rotateInDownLeft
+	h1a-rotateInDownRight = H1 Title rotateInDownRight
+	h1a-rotateInUpLeft = H1 Title rotateInUpLeft
+	h1a-rotateInUpRight = H1 Title rotateInUpRight
+
+	h1a-RotatingExits = -- Rotating Exits --
+
+	h1a-rotateOut = H1 Title rotateOut
+	h1a-rotateOutDownLeft = H1 Title rotateOutDownLeft
+	h1a-rotateOutDownRight = H1 Title rotateOutDownRight
+	h1a-rotateOutUpLeft = H1 Title rotateOutUpLeft
+	h1a-rotateOutUpRight = H1 Title rotateOutUpRight
+
+	h1a-SlidingEntrances = -- Sliding Entrances --
+
+	h1a-slideInDown = H1 Title slideInDown
+	h1a-slideInLeft = H1 Title slideInLeft
+	h1a-slideInRight = H1 Title slideInRight
+	h1a-slideInUp = H1 Title slideInUp
+
+	h1a-SlidingExits = -- Sliding Exits --
+
+	h1a-slideOutDown = H1 Title slideOutDown
+	h1a-slideOutLeft = H1 Title slideOutLeft
+	h1a-slideOutRight = H1 Title slideOutRight
+	h1a-slideOutUp = H1 Title slideOutUp
+
+	h1a-ZoomEntrances = -- Zoom Entrances --
+
+	h1a-zoomIn = H1 Title zoomIn
+	h1a-zoomInDown = H1 Title zoomInDown
+	h1a-zoomInLeft = H1 Title zoomInLeft
+	h1a-zoomInRight = H1 Title zoomInRight
+	h1a-zoomInUp = H1 Title zoomInUp
+
+	h1a-ZoomExits = -- Zoom Exits --
+
+	h1a-zoomOut = H1 Title zoomOut
+	h1a-zoomOutDown = H1 Title zoomOutDown
+	h1a-zoomOutLeft = H1 Title zoomOutLeft
+	h1a-zoomOutRight = H1 Title zoomOutRight
+	h1a-zoomOutUp = H1 Title zoomOutUp
+
+	h1a-Specials = -- Specials --
+
+	h1a-hinge = H1 Title hinge
+	h1a-rollIn = H1 Title rollIn
+	h1a-rollOut = H1 Title rollOut
+
+    h2a-AttentionSeekers = -- Attention Seekers --
+
+    h2a-bounce = H2 Title bounce
+    h2a-flash = H2 Title flash
+    h2a-pulse = H2 Title pulse
+    h2a-rubberBand = H2 Title rubberBand
+    h2a-shake = H2 Title shake
+    h2a-swing = H2 Title swing
+    h2a-tada = H2 Title tada
+    h2a-wobble = H2 Title wobble
+    h2a-jello = H2 Title jello
+
+    h2a-BouncingEntrances = -- Bouncing Entrances --
+
+    h2a-bounceIn = H2 Title bounceIn
+    h2a-bounceInDown = H2 Title bounceInDown
+	h2a-bounceInLeft = H2 Title bounceInLeft
+	h2a-bounceInRight = H2 Title bounceInRight
+	h2a-bounceInUp = H2 Title bounceInUp
+
+	h2a-BouncingExits = -- Bouncing Exits
+
+	h2a-bounceOut = H2 Title bounceOut
+	h2a-bounceOutDown = H2 Title bounceOutDown
+	h2a-bounceOutLeft = H2 Title bounceOutLeft
+	h2a-bounceOutRight = H2 Title bounceOutRight
+	h2a-bounceOutUp = H2 Title bounceOutUp
+
+	h2a-FadingEntrances = -- Fading Entrances --
+
+	h2a-fadeIn = H2 Title fadeIn
+	h2a-fadeInDown = H2 Title fadeInDown
+	h2a-fadeInDownBig = H2 Title fadeInDownBig
+	h2a-fadeInLeft = H2 Title fadeInLeft
+	h2a-fadeInLeftBig = H2 Title fadeInLeftBig
+	h2a-fadeInRight = H2 Title fadeInRight
+	h2a-fadeInRightBig = H2 Title fadeInRightBig
+	h2a-fadeInUp = H2 Title fadeInUp
+	h2a-fadeInUpBig = H2 Title fadeInUpBig
+
+	h2a-FadingExits = -- Fading Exits --
+
+	h2a-fadeOut = H2 Title fadeOut
+	h2a-fadeOutDown = H2 Title fadeOutDown
+	h2a-fadeOutDownBig = H2 Title fadeOutDownBig
+	h2a-fadeOutLeft = H2 Title fadeOutLeft
+	h2a-fadeOutLeftBig = H2 Title fadeOutLeftBig
+	h2a-fadeOutRight = H2 Title fadeOutRight
+	h2a-fadeOutRightBig = H2 Title fadeOutRightBig
+	h2a-fadeOutUp = H2 Title fadeOutUp
+	h2a-fadeOutUpBig = H2 Title fadeOutUpBig
+
+	h2a-Flippers = -- Flippers --
+
+	h2a-flip = H2 Title flip
+	h2a-flipInX = H2 Title flipInX
+	h2a-flipInY = H2 Title flipInY
+	h2a-flipOutX = H2 Title flipOutX
+	h2a-flipOutY = H2 Title flipOutY
+
+	h2a-Lightspeed = -- Lightspeed --
+
+	h2a-lightSpeedIn = H2 Title lightSpeedIn
+	h2a-lightSpeedOut = H2 Title lightSpeedOut
+
+	h2a-RotatingEntrances = -- Rotating Entrances --
+
+	h2a-rotateIn = H2 Title rotateIn
+	h2a-rotateInDownLeft = H2 Title rotateInDownLeft
+	h2a-rotateInDownRight = H2 Title rotateInDownRight
+	h2a-rotateInUpLeft = H2 Title rotateInUpLeft
+	h2a-rotateInUpRight = H2 Title rotateInUpRight
+
+	h2a-RotatingExits = -- Rotating Exits --
+
+	h2a-rotateOut = H2 Title rotateOut
+	h2a-rotateOutDownLeft = H2 Title rotateOutDownLeft
+	h2a-rotateOutDownRight = H2 Title rotateOutDownRight
+	h2a-rotateOutUpLeft = H2 Title rotateOutUpLeft
+	h2a-rotateOutUpRight = H2 Title rotateOutUpRight
+
+	h2a-SlidingEntrances = -- Sliding Entrances --
+
+	h2a-slideInDown = H2 Title slideInDown
+	h2a-slideInLeft = H2 Title slideInLeft
+	h2a-slideInRight = H2 Title slideInRight
+	h2a-slideInUp = H2 Title slideInUp
+
+	h2a-SlidingExits = -- Sliding Exits --
+
+	h2a-slideOutDown = H2 Title slideOutDown
+	h2a-slideOutLeft = H2 Title slideOutLeft
+	h2a-slideOutRight = H2 Title slideOutRight
+	h2a-slideOutUp = H2 Title slideOutUp
+
+	h2a-ZoomEntrances = -- Zoom Entrances --
+
+	h2a-zoomIn = H2 Title zoomIn
+	h2a-zoomInDown = H2 Title zoomInDown
+	h2a-zoomInLeft = H2 Title zoomInLeft
+	h2a-zoomInRight = H2 Title zoomInRight
+	h2a-zoomInUp = H2 Title zoomInUp
+
+	h2a-ZoomExits = -- Zoom Exits --
+
+	h2a-zoomOut = H2 Title zoomOut
+	h2a-zoomOutDown = H2 Title zoomOutDown
+	h2a-zoomOutLeft = H2 Title zoomOutLeft
+	h2a-zoomOutRight = H2 Title zoomOutRight
+	h2a-zoomOutUp = H2 Title zoomOutUp
+
+	h2a-Specials = -- Specials --
+
+	h2a-hinge = H2 Title hinge
+	h2a-rollIn = H2 Title rollIn
+	h2a-rollOut = H2 Title rollOut
 
 }
 

--- a/Configuration/PageTS/Library/tceform.pagets
+++ b/Configuration/PageTS/Library/tceform.pagets
@@ -1,14 +1,24 @@
 ## Rename Layout-types
-TCEFORM.tt_content.header_layout.altLabels {
-    1 = H3 (primary font)
-    2 = H4 (primary font)
-    3 = H5 (primary font)
-	4 = H2 text-color, no border
-	5 = H3 border bottom
-}
+//TCEFORM.tt_content.header_layout.altLabels {
+//    1 = H1 (primary font)
+//    2 = H2 (primary font)
+//    3 = H3 (primary font)
+//	  4 = H4 (primary font)
+//	  5 = H5 (primary font)
+//}
 TCEFORM.tt_content.header_layout.addItems {
-    6 = H1 Carousel Title fadeInDown
-    7 = H1 Carousel Title slideInLeft
+    6 = H2 Block Header
+    7 = H2 Block Header Row
+    8 = Horizontal Line - No Header Text
+    1000 = ---
+    1001 = H1 Title fadeInDown
+    1002 = H1 Title fadeInUp
+    1003 = H1 Title slideInLeft
+    1004 = H1 Title slideInRight
+    2000 = ---
+    2001 = H2 Block Header
+    2002 = H2 Block Header Row
+
 }
 
 TCEFORM.pages {

--- a/Configuration/TypoScript/Library/lib.content.stdheader.setupts
+++ b/Configuration/TypoScript/Library/lib.content.stdheader.setupts
@@ -15,7 +15,7 @@ lib.stdheader {
         2 = TEXT
         2 {
             current = 1
-            dataWrap = <h2 class="text-color {register:headerClass}">|</h2>
+            dataWrap = <h2 class="primary-font text-color {register:headerClass}">|</h2>
         }
         3 = TEXT
         3 {
@@ -27,79 +27,847 @@ lib.stdheader {
             current = 1
             dataWrap = <h4 class="primary-font {register:headerClass}">|</h4>
         }
-		6 = TEXT
-		6 {
-			current = 1
-			dataWrap = <div class="block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div>
-		}
-
-		7 = TEXT
-		7 {
-			current = 1
-			dataWrap = <div class="row"><div class="col-md-12 block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div></div>
-		}
         8 = TEXT
         8 {
             current = 1
             dataWrap = <h3 class="headline text-color {register:headerClass}"><span class="border-color">|</span></h3>
         }
-        1001 = TEXT
-        1001 {
-            current = 1
-            dataWrap = <h1 class="animated fadeInDown {register:headerClass}">|</h1>
-        }
-        1002 = TEXT
-        1002 {
-            current = 1
-            dataWrap = <h1 class="animated fadeInUp {register:headerClass}">|</h1>
-        }
-		1003 = TEXT
-		1003 {
+
+		// Animated CSS Headers https://daneden.github.io/animated.css/
+		// h1a-AttentionSeekers = -- Attention Seekers --
+
+		h1a-bounce = TEXT
+		h1a-bounce {
 			current = 1
-			split{
-				token = |
-				cObjNum = 1||2
-				1{
-					current = 1
-					wrap = |</br>
-				}
-				2{
-					current = 1
-					wrap = |
-				}
-			}
+		    dataWrap = <h1 class="animated bounce {register:headerClass}">|</h1>
+		}
+		h1a-flash = TEXT
+		h1a-flash {
+			current = 1
+			dataWrap = <h1 class="animated flash {register:headerClass}">|</h1>
+		}
+		h1a-pulse = TEXT
+		h1a-pulse {
+			current = 1
+			dataWrap = <h1 class="animated pulse {register:headerClass}">|</h1>
+		}
+		h1a-rubberBand = TEXT
+		h1a-rubberBand {
+			current = 1
+			dataWrap = <h1 class="animated rubberBand {register:headerClass}">|</h1>
+		}
+		h1a-shake = TEXT
+		h1a-shake {
+			current = 1
+			dataWrap = <h1 class="animated shake {register:headerClass}">|</h1>
+		}
+		h1a-swing = TEXT
+		h1a-swing {
+			current = 1
+			dataWrap = <h1 class="animated swing {register:headerClass}">|</h1>
+		}
+		h1a-tada = TEXT
+		h1a-tada {
+			current = 1
+			dataWrap = <h1 class="animated tada {register:headerClass}">|</h1>
+		}
+		h1a-wobble = TEXT
+		h1a-wobble {
+			current = 1
+			dataWrap = <h1 class="animated wobble {register:headerClass}">|</h1>
+		}
+		h1a-jello = TEXT
+		h1a-jello {
+			current = 1
+			dataWrap = <h1 class="animated jello {register:headerClass}">|</h1>
+		}
+
+		// h1a-BouncingEntrances = -- Bouncing Entrances --
+
+		h1a-bounceIn = TEXT
+		h1a-bounceIn {
+			current = 1
+			dataWrap = <h1 class="animated bounceIn {register:headerClass}">|</h1>
+		}
+		h1a-bounceInDown = TEXT
+		h1a-bounceInDown {
+			current = 1
+			dataWrap = <h1 class="animated bounceInDown {register:headerClass}">|</h1>
+		}
+		h1a-bounceInLeft = TEXT
+		h1a-bounceInLeft {
+			current = 1
+			dataWrap = <h1 class="animated bounceInLeft {register:headerClass}">|</h1>
+		}
+		h1a-bounceInRight = TEXT
+		h1a-bounceInRight {
+			current = 1
+			dataWrap = <h1 class="animated bounceInRight {register:headerClass}">|</h1>
+		}
+		h1a-bounceInUp = TEXT
+		h1a-bounceInUp {
+			current = 1
+			dataWrap = <h1 class="animated bounceInUp {register:headerClass}">|</h1>
+		}
+
+		// h1a-BouncingExits = -- Bouncing Exits
+
+		h1a-bounceOut = TEXT
+		h1a-bounceOut {
+			current = 1
+			dataWrap = <h1 class="animated bounceOut {register:headerClass}">|</h1>
+		}
+		h1a-bounceOutDown = TEXT
+		h1a-bounceOutDown {
+			current = 1
+			dataWrap = <h1 class="animated bounceOutDown {register:headerClass}">|</h1>
+		}
+		h1a-bounceOutLeft = TEXT
+		h1a-bounceOutLeft {
+			current = 1
+			dataWrap = <h1 class="animated bounceOutLeft {register:headerClass}">|</h1>
+		}
+		h1a-bounceOutRight = TEXT
+		h1a-bounceOutRight {
+			current = 1
+			dataWrap = <h1 class="animated bounceOutRight {register:headerClass}">|</h1>
+		}
+		h1a-bounceOutUp = TEXT
+		h1a-bounceOutUp {
+			current = 1
+			dataWrap = <h1 class="animated bounceOutUp {register:headerClass}">|</h1>
+		}
+
+
+		// h1a-FadingEntrances = -- Fading Entrances --
+
+		h1a-fadeIn = TEXT
+		h1a-fadeIn {
+			current = 1
+			dataWrap = <h1 class="animated fadeIn {register:headerClass}">|</h1>
+		}
+		h1a-fadeInDown = TEXT
+		h1a-fadeInDown {
+			current = 1
+			dataWrap = <h1 class="animated fadeInDown {register:headerClass}">|</h1>
+		}
+		h1a-fadeInDownBig = TEXT
+		h1a-fadeInDownBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeInDownBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeInLeft = TEXT
+		h1a-fadeInLeft {
+			current = 1
+			dataWrap = <h1 class="animated fadeInLeft {register:headerClass}">|</h1>
+		}
+		h1a-fadeInLeftBig = TEXT
+		h1a-fadeInLeftBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeInLeftBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeInRight = TEXT
+		h1a-fadeInRight {
+			current = 1
+			dataWrap = <h1 class="animated fadeInRight {register:headerClass}">|</h1>
+		}
+		h1a-fadeInRightBig = TEXT
+		h1a-fadeInRightBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeInRightBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeInUp = TEXT
+		h1a-fadeInUp {
+			current = 1
+			dataWrap = <h1 class="animated fadeInUp {register:headerClass}">|</h1>
+		}
+		h1a-fadeInUpBig = TEXT
+		h1a-fadeInUpBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeInUpBig {register:headerClass}">|</h1>
+		}
+
+		// h1a-FadingExits = -- Fading Exits --
+
+		h1a-fadeOut = TEXT
+		h1a-fadeOut {
+			current = 1
+			dataWrap = <h1 class="animated fadeOut {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutDown = TEXT
+		h1a-fadeOutDown {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutDown {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutDownBig = TEXT
+		h1a-fadeOutDownBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutDownBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutLeft = TEXT
+		h1a-fadeOutLeft {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutLeft {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutLeftBig = TEXT
+		h1a-fadeOutLeftBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutLeftBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutRight = TEXT
+		h1a-fadeOutRight {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutRight {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutRightBig = TEXT
+		h1a-fadeOutRightBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutRightBig {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutUp = TEXT
+		h1a-fadeOutUp {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutUp {register:headerClass}">|</h1>
+		}
+		h1a-fadeOutUpBig = TEXT
+		h1a-fadeOutUpBig {
+			current = 1
+			dataWrap = <h1 class="animated fadeOutUpBig {register:headerClass}">|</h1>
+		}
+
+		// h1a-Flippers = -- Flippers --
+
+		h1a-flip = TEXT
+		h1a-flip {
+			current = 1
+			dataWrap = <h1 class="animated flip {register:headerClass}">|</h1>
+		}
+		h1a-flipInX = TEXT
+		h1a-flipInX {
+			current = 1
+			dataWrap = <h1 class="animated flipInX {register:headerClass}">|</h1>
+		}
+		h1a-flipInY = TEXT
+		h1a-flipInY {
+			current = 1
+			dataWrap = <h1 class="animated flipInY {register:headerClass}">|</h1>
+		}
+		h1a-flipOutX = TEXT
+		h1a-flipOutX {
+			current = 1
+			dataWrap = <h1 class="animated flipOutX {register:headerClass}">|</h1>
+		}
+		h1a-flipOutY = TEXT
+		h1a-flipOutY {
+			current = 1
+			dataWrap = <h1 class="animated flipOutY {register:headerClass}">|</h1>
+		}
+
+		// h1a-Lightspeed = -- Lightspeed --
+
+		h1a-lightSpeedIn = TEXT
+		h1a-lightSpeedIn {
+			current = 1
+			dataWrap = <h1 class="animated lightSpeedIn {register:headerClass}">|</h1>
+		}
+		h1a-lightSpeedOut = TEXT
+		h1a-lightSpeedOut {
+			current = 1
+			dataWrap = <h1 class="animated lightSpeedOut {register:headerClass}">|</h1>
+		}
+
+		// h1a-RotatingEntrances = -- Rotating Entrances --
+
+		h1a-rotateIn = TEXT
+		h1a-rotateIn {
+			current = 1
+			dataWrap = <h1 class="animated rotateIn {register:headerClass}">|</h1>
+		}
+		h1a-rotateInDownLeft = TEXT
+		h1a-rotateInDownLeft {
+			current = 1
+			dataWrap = <h1 class="animated rotateInDownLeft {register:headerClass}">|</h1>
+		}
+		h1a-rotateInDownRight = TEXT
+		h1a-rotateInDownRight {
+			current = 1
+			dataWrap = <h1 class="animated rotateInDownRight {register:headerClass}">|</h1>
+		}
+		h1a-rotateInUpLeft = TEXT
+		h1a-rotateInUpLeft {
+			current = 1
+			dataWrap = <h1 class="animated rotateInUpLeft {register:headerClass}">|</h1>
+		}
+		h1a-rotateInUpRight = TEXT
+		h1a-rotateInUpRight {
+			current = 1
+			dataWrap = <h1 class="animated rotateInUpRight {register:headerClass}">|</h1>
+		}
+
+		// h1a-RotatingExits = -- Rotating Exits --
+
+		h1a-rotateOut = TEXT
+		h1a-rotateOut {
+			current = 1
+			dataWrap = <h1 class="animated rotateOut {register:headerClass}">|</h1>
+		}
+		h1a-rotateOutDownLeft = TEXT
+		h1a-rotateOutDownLeft {
+			current = 1
+			dataWrap = <h1 class="animated rotateOutDownLeft {register:headerClass}">|</h1>
+		}
+		h1a-rotateOutDownRight = TEXT
+		h1a-rotateOutDownRight {
+			current = 1
+		    dataWrap = <h1 class="animated rotateOutDownRight {register:headerClass}">|</h1>
+		}
+		h1a-rotateOutUpLeft = TEXT
+		h1a-rotateOutUpLeft {
+			current = 1
+			dataWrap = <h1 class="animated rotateOutUpLeft {register:headerClass}">|</h1>
+		}
+		h1a-rotateOutUpRight = TEXT
+		h1a-rotateOutUpRight {
+			current = 1
+			dataWrap = <h1 class="animated rotateOutUpRight {register:headerClass}">|</h1>
+		}
+
+		// h1a-SlidingEntrances = -- Sliding Entrances --
+
+		h1a-slideInDown = TEXT
+		h1a-slideInDown {
+			current = 1
+			dataWrap = <h1 class="animated slideInDown {register:headerClass}">|</h1>
+		}
+		h1a-slideInLeft = TEXT
+		h1a-slideInLeft {
+			current = 1
 			dataWrap = <h1 class="animated slideInLeft {register:headerClass}">|</h1>
 		}
-		1004 = TEXT
-		1004 {
+		h1a-slideInRight = TEXT
+		h1a-slideInRight {
 			current = 1
-			split{
-				token = |
-				cObjNum = 1||2
-				1{
-					current = 1
-					wrap = |</br>
-				}
-				2{
-					current = 1
-					wrap = |
-				}
-			}
 			dataWrap = <h1 class="animated slideInRight {register:headerClass}">|</h1>
 		}
-		2001 = TEXT
-		2001 {
+		h1a-slideInUp = TEXT
+		h1a-slideInUp {
 			current = 1
-			dataWrap = <div class="block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div>
+			dataWrap = <h1 class="animated slideInUp {register:headerClass}">|</h1>
 		}
 
-		2002 = TEXT
-		2002 {
+		// h1a-SlidingExits = -- Sliding Exits --
+
+		h1a-slideOutDown = TEXT
+		h1a-slideOutDown {
 			current = 1
-			dataWrap = <div class="row"><div class="col-md-12 block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div></div>
+			dataWrap = <h1 class="animated slideOutDown {register:headerClass}">|</h1>
+		}
+		h1a-slideOutLeft = TEXT
+		h1a-slideOutLeft {
+			current = 1
+			dataWrap = <h1 class="animated slideOutLeft {register:headerClass}">|</h1>
+		}
+		h1a-slideOutRight = TEXT
+		h1a-slideOutRight {
+			current = 1
+			dataWrap = <h1 class="animated slideOutRight {register:headerClass}">|</h1>
+		}
+		h1a-slideOutUp = TEXT
+		h1a-slideOutUp {
+		    current = 1
+			dataWrap = <h1 class="animated slideOutUp {register:headerClass}">|</h1>
 		}
 
+		// h1a-ZoomEntrances = -- Zoom Entrances --
 
+		h1a-zoomIn = TEXT
+		h1a-zoomIn {
+			current = 1
+			dataWrap = <h1 class="animated zoomIn {register:headerClass}">|</h1>
+		}
+		h1a-zoomInDown = TEXT
+		h1a-zoomInDown {
+			current = 1
+			dataWrap = <h1 class="animated zoomInDown {register:headerClass}">|</h1>
+		}
+		h1a-zoomInLeft = TEXT
+		h1a-zoomInLeft {
+			current = 1
+			dataWrap = <h1 class="animated zoomInLeft {register:headerClass}">|</h1>
+		}
+		h1a-zoomInRight = TEXT
+		h1a-zoomInRight {
+			current = 1
+			dataWrap = <h1 class="animated zoomInRight {register:headerClass}">|</h1>
+		}
+		h1a-zoomInUp = TEXT
+		h1a-zoomInUp {
+			current = 1
+			dataWrap = <h1 class="animated zoomInUp {register:headerClass}">|</h1>
+		}
+
+		// h1a-ZoomExits = -- Zoom Exits --
+
+		h1a-zoomOut = TEXT
+		h1a-zoomOut {
+			current = 1
+			dataWrap = <h1 class="animated zoomOut {register:headerClass}">|</h1>
+		}
+		h1a-zoomOutDown = TEXT
+		h1a-zoomOutDown {
+			current = 1
+			dataWrap = <h1 class="animated zoomOutDown {register:headerClass}">|</h1>
+		}
+		h1a-zoomOutLeft = TEXT
+		h1a-zoomOutLeft {
+			current = 1
+			dataWrap = <h1 class="animated zoomOutLeft {register:headerClass}">|</h1>
+		}
+		h1a-zoomOutRight = TEXT
+		h1a-zoomOutRight {
+			current = 1
+			dataWrap = <h1 class="animated zoomOutRight {register:headerClass}">|</h1>
+		}
+		h1a-zoomOutUp = TEXT
+		h1a-zoomOutUp {
+			current = 1
+			dataWrap = <h1 class="animated  zoomOutUp  {register:headerClass}">|</h1>
+		}
+
+		// h1a-Specials = -- Specials --
+
+		h1a-hinge = TEXT
+		h1a-hinge {
+			current = 1
+			dataWrap = <h1 class="animated hinge {register:headerClass}">|</h1>
+		}
+		h1a-rollIn = TEXT
+		h1a-rollIn {
+			current = 1
+			dataWrap = <h1 class="animated rollIn {register:headerClass}">|</h1>
+		}
+		h1a-rollOut = TEXT
+		h1a-rollOut {
+			current = 1
+			dataWrap = <h1 class="animated rollOut {register:headerClass}">|</h1>
+		}
+
+		// h2a-AttentionSeekers = -- Attention Seekers --
+
+		h2a-bounce = TEXT
+		h2a-bounce {
+			current = 1
+			dataWrap = <h2 class="animated bounce {register:headerClass}">|</h2>
+		}
+		h2a-flash = TEXT
+		h2a-flash {
+			current = 1
+			dataWrap = <h2 class="animated flash {register:headerClass}">|</h2>
+		}
+		h2a-pulse = TEXT
+		h2a-pulse {
+			current = 1
+			dataWrap = <h2 class="animated pulse {register:headerClass}">|</h2>
+		}
+		h2a-rubberBand = TEXT
+		h2a-rubberBand {
+			current = 1
+			dataWrap = <h2 class="animated rubberBand {register:headerClass}">|</h2>
+		}
+		h2a-shake = TEXT
+		h2a-shake {
+			current = 1
+			dataWrap = <h2 class="animated shake {register:headerClass}">|</h2>
+		}
+		h2a-swing = TEXT
+		h2a-swing {
+			current = 1
+			dataWrap = <h2 class="animated swing {register:headerClass}">|</h2>
+		}
+		h2a-tada = TEXT
+		h2a-tada {
+			current = 1
+			dataWrap = <h2 class="animated tada {register:headerClass}">|</h2>
+		}
+		h2a-wobble = TEXT
+		h2a-wobble {
+			current = 1
+			dataWrap = <h2 class="animated wobble {register:headerClass}">|</h2>
+		}
+		h2a-jello = TEXT
+		h2a-jello {
+			current = 1
+			dataWrap = <h2 class="animated jello {register:headerClass}">|</h2>
+		}
+
+		// h2a-BouncingEntrances = -- Bouncing Entrances --
+
+		h2a-bounceIn = TEXT
+		h2a-bounceIn {
+			current = 1
+			dataWrap = <h2 class="animated bounceIn {register:headerClass}">|</h2>
+		}
+		h2a-bounceInDown = TEXT
+		h2a-bounceInDown {
+			current = 1
+			dataWrap = <h2 class="animated bounceInDown {register:headerClass}">|</h2>
+		}
+		h2a-bounceInLeft = TEXT
+		h2a-bounceInLeft {
+			current = 1
+			dataWrap = <h2 class="animated bounceInLeft {register:headerClass}">|</h2>
+		}
+		h2a-bounceInRight = TEXT
+		h2a-bounceInRight {
+			current = 1
+			dataWrap = <h2 class="animated bounceInRight {register:headerClass}">|</h2>
+		}
+		h2a-bounceInUp = TEXT
+		h2a-bounceInUp {
+			current = 1
+			dataWrap = <h2 class="animated bounceInUp {register:headerClass}">|</h2>
+		}
+
+		// h2a-BouncingExits = -- Bouncing Exits
+
+		h2a-bounceOut = TEXT
+		h2a-bounceOut {
+			current = 1
+			dataWrap = <h2 class="animated bounceOut {register:headerClass}">|</h2>
+		}
+		h2a-bounceOutDown = TEXT
+		h2a-bounceOutDown {
+			current = 1
+			dataWrap = <h2 class="animated bounceOutDown {register:headerClass}">|</h2>
+		}
+		h2a-bounceOutLeft = TEXT
+		h2a-bounceOutLeft {
+			current = 1
+			dataWrap = <h2 class="animated bounceOutLeft {register:headerClass}">|</h2>
+		}
+		h2a-bounceOutRight = TEXT
+		h2a-bounceOutRight {
+			current = 1
+			dataWrap = <h2 class="animated bounceOutRight {register:headerClass}">|</h2>
+		}
+		h2a-bounceOutUp = TEXT
+		h2a-bounceOutUp {
+			current = 1
+			dataWrap = <h2 class="animated bounceOutUp {register:headerClass}">|</h2>
+		}
+
+		// h2a-FadingEntrances = -- Fading Entrances --
+
+		h2a-fadeIn = TEXT
+		h2a-fadeIn {
+			current = 1
+			dataWrap = <h2 class="animated fadeIn {register:headerClass}">|</h2>
+		}
+		h2a-fadeInDown = TEXT
+		h2a-fadeInDown {
+			current = 1
+			dataWrap = <h2 class="animated fadeInDown {register:headerClass}">|</h2>
+		}
+		h2a-fadeInDownBig = TEXT
+		h2a-fadeInDownBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeInDownBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeInLeft = TEXT
+		h2a-fadeInLeft {
+			current = 1
+			dataWrap = <h2 class="animated fadeInLeft {register:headerClass}">|</h2>
+		}
+		h2a-fadeInLeftBig = TEXT
+		h2a-fadeInLeftBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeInLeftBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeInRight = TEXT
+		h2a-fadeInRight {
+			current = 1
+			dataWrap = <h2 class="animated fadeInRight {register:headerClass}">|</h2>
+		}
+		h2a-fadeInRightBig = TEXT
+		h2a-fadeInRightBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeInRightBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeInUp = TEXT
+		h2a-fadeInUp {
+			current = 1
+			dataWrap = <h2 class="animated fadeInUp {register:headerClass}">|</h2>
+		}
+		h2a-fadeInUpBig = TEXT
+		h2a-fadeInUpBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeInUpBig {register:headerClass}">|</h2>
+		}
+
+		// h2a-FadingExits = -- Fading Exits --
+
+		h2a-fadeOut = TEXT
+		h2a-fadeOut {
+			current = 1
+			dataWrap = <h2 class="animated fadeOut {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutDown = TEXT
+		h2a-fadeOutDown {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutDown {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutDownBig = TEXT
+		h2a-fadeOutDownBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutDownBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutLeft = TEXT
+		h2a-fadeOutLeft {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutLeft {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutLeftBig = TEXT
+		h2a-fadeOutLeftBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutLeftBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutRight = TEXT
+		h2a-fadeOutRight {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutRight {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutRightBig = TEXT
+		h2a-fadeOutRightBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutRightBig {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutUp = TEXT
+		h2a-fadeOutUp {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutUp {register:headerClass}">|</h2>
+		}
+		h2a-fadeOutUpBig = TEXT
+		h2a-fadeOutUpBig {
+			current = 1
+			dataWrap = <h2 class="animated fadeOutUpBig {register:headerClass}">|</h2>
+		}
+
+		// h2a-Flippers = -- Flippers --
+
+		h2a-flip = TEXT
+		h2a-flip {
+			current = 1
+			dataWrap = <h2 class="animated flip {register:headerClass}">|</h2>
+		}
+		h2a-flipInX = TEXT
+		h2a-flipInX {
+			current = 1
+			dataWrap = <h2 class="animated flipInX {register:headerClass}">|</h2>
+		}
+		h2a-flipInY = TEXT
+		h2a-flipInY {
+			current = 1
+			dataWrap = <h2 class="animated flipInY {register:headerClass}">|</h2>
+		}
+		h2a-flipOutX = TEXT
+		h2a-flipOutX {
+			current = 1
+			dataWrap = <h2 class="animated flipOutX {register:headerClass}">|</h2>
+		}
+		h2a-flipOutY = TEXT
+		h2a-flipOutY {
+			current = 1
+			dataWrap = <h2 class="animated flipOutY {register:headerClass}">|</h2>
+		}
+
+		// h2a-Lightspeed = -- Lightspeed --
+
+		h2a-lightSpeedIn = TEXT
+		h2a-lightSpeedIn {
+			current = 1
+			dataWrap = <h2 class="animated lightSpeedIn {register:headerClass}">|</h2>
+		}
+		h2a-lightSpeedOut = TEXT
+		h2a-lightSpeedOut {
+			current = 1
+			dataWrap = <h2 class="animated lightSpeedOut {register:headerClass}">|</h2>
+		}
+
+		// h2a-RotatingEntrances = -- Rotating Entrances --
+
+		h2a-rotateIn = TEXT
+		h2a-rotateIn {
+			current = 1
+			dataWrap = <h2 class="animated rotateIn {register:headerClass}">|</h2>
+		}
+		h2a-rotateInDownLeft = TEXT
+		h2a-rotateInDownLeft {
+			current = 1
+			dataWrap = <h2 class="animated rotateInDownLeft {register:headerClass}">|</h2>
+		}
+		h2a-rotateInDownRight = TEXT
+		h2a-rotateInDownRight {
+			current = 1
+			dataWrap = <h2 class="animated rotateInDownRight {register:headerClass}">|</h2>
+		}
+		h2a-rotateInUpLeft = TEXT
+		h2a-rotateInUpLeft {
+			current = 1
+			dataWrap = <h2 class="animated rotateInUpLeft {register:headerClass}">|</h2>
+		}
+		h2a-rotateInUpRight = TEXT
+		h2a-rotateInUpRight {
+			current = 1
+			dataWrap = <h2 class="animated rotateInUpRight {register:headerClass}">|</h2>
+		}
+
+		// h2a-RotatingExits = -- Rotating Exits --
+
+		h2a-rotateOut = TEXT
+		h2a-rotateOut {
+			current = 1
+			dataWrap = <h2 class="animated rotateOut {register:headerClass}">|</h2>
+		}
+		h2a-rotateOutDownLeft = TEXT
+		h2a-rotateOutDownLeft {
+			current = 1
+			dataWrap = <h2 class="animated rotateOutDownLeft {register:headerClass}">|</h2>
+		}
+		h2a-rotateOutDownRight = TEXT
+		h2a-rotateOutDownRight {
+			current = 1
+			dataWrap = <h2 class="animated rotateOutDownRight {register:headerClass}">|</h2>
+		}
+		h2a-rotateOutUpLeft = TEXT
+		h2a-rotateOutUpLeft {
+			current = 1
+			dataWrap = <h2 class="animated rotateOutUpLeft {register:headerClass}">|</h2>
+		}
+		h2a-rotateOutUpRight = TEXT
+		h2a-rotateOutUpRight {
+			current = 1
+		    dataWrap = <h2 class="animated rotateOutUpRight {register:headerClass}">|</h2>
+		}
+
+		// h2a-SlidingEntrances = -- Sliding Entrances --
+
+		h2a-slideInDown = TEXT
+		h2a-slideInDown {
+			current = 1
+		    dataWrap = <h2 class="animated slideInDown {register:headerClass}">|</h2>
+		}
+		h2a-slideInLeft = TEXT
+		h2a-slideInLeft {
+			current = 1
+			dataWrap = <h2 class="animated slideInLeft {register:headerClass}">|</h2>
+		}
+		h2a-slideInRight = TEXT
+		h2a-slideInRight {
+			current = 1
+			dataWrap = <h2 class="animated slideInRight {register:headerClass}">|</h2>
+		}
+		h2a-slideInUp = TEXT
+		h2a-slideInUp {
+			current = 1
+			dataWrap = <h2 class="animated slideInUp {register:headerClass}">|</h2>
+		}
+
+		// h2a-SlidingExits = -- Sliding Exits --
+
+		h2a-slideOutDown = TEXT
+		h2a-slideOutDown {
+			current = 1
+			dataWrap = <h2 class="animated slideOutDown {register:headerClass}">|</h2>
+		}
+		h2a-slideOutLeft = TEXT
+		h2a-slideOutLeft {
+			current = 1
+			dataWrap = <h2 class="animated slideOutLeft {register:headerClass}">|</h2>
+		}
+		h2a-slideOutRight = TEXT
+		h2a-slideOutRight {
+			current = 1
+			dataWrap = <h2 class="animated slideOutRight {register:headerClass}">|</h2>
+		}
+		h2a-slideOutUp = TEXT
+		h2a-slideOutUp {
+			current = 1
+			dataWrap = <h2 class="animated slideOutUp {register:headerClass}">|</h2>
+		}
+
+		// h2a-ZoomEntrances = -- Zoom Entrances --
+
+		h2a-zoomIn = TEXT
+		h2a-zoomIn {
+		    current = 1
+			dataWrap = <h2 class="animated zoomIn {register:headerClass}">|</h2>
+		}
+		h2a-zoomInDown = TEXT
+		h2a-zoomInDown {
+			current = 1
+			dataWrap = <h2 class="animated zoomInDown {register:headerClass}">|</h2>
+		}
+		h2a-zoomInLeft = TEXT
+		h2a-zoomInLeft {
+			current = 1
+			dataWrap = <h2 class="animated zoomInLeft {register:headerClass}">|</h2>
+		}
+		h2a-zoomInRight = TEXT
+		h2a-zoomInRight {
+			current = 1
+			dataWrap = <h2 class="animated zoomInRight {register:headerClass}">|</h2>
+		}
+		h2a-zoomInUp = TEXT
+		h2a-zoomInUp {
+			current = 1
+			dataWrap = <h2 class="animated zoomInUp {register:headerClass}">|</h2>
+		}
+
+		// h2a-ZoomExits = -- Zoom Exits --
+
+		h2a-zoomOut = TEXT
+		h2a-zoomOut {
+			current = 1
+			dataWrap = <h2 class="animated zoomOut {register:headerClass}">|</h2>
+		}
+		h2a-zoomOutDown = TEXT
+		h2a-zoomOutDown {
+			current = 1
+			dataWrap = <h2 class="animated zoomOutDown {register:headerClass}">|</h2>
+		}
+		h2a-zoomOutLeft = TEXT
+		h2a-zoomOutLeft {
+			current = 1
+			dataWrap = <h2 class="animated zoomOutLeft {register:headerClass}">|</h2>
+		}
+		h2a-zoomOutRight = TEXT
+		h2a-zoomOutRight {
+			current = 1
+			dataWrap = <h2 class="animated zoomOutRight {register:headerClass}">|</h2>
+		}
+		h2a-zoomOutUp = TEXT
+		h2a-zoomOutUp {
+			current = 1
+			dataWrap = <h2 class="animated  zoomOutUp  {register:headerClass}">|</h2>
+		}
+
+		// h2a-Specials = -- Specials --
+
+		h2a-hinge = TEXT
+		h2a-hinge {
+		    current = 1
+		    dataWrap = <h2 class="animated hinge {register:headerClass}">|</h2>
+		}
+		h2a-rollIn = TEXT
+		h2a-rollIn {
+		    current = 1
+			dataWrap = <h2 class="animated rollIn {register:headerClass}">|</h2>
+		}
+		h2a-rollOut = TEXT
+		h2a-rollOut {
+		    current = 1
+	    	dataWrap = <h2 class="animated rollOut {register:headerClass}">|</h2>
+		}
 	}
 	20 {
 		1.wrap = <h2 class="hl">|</h2>

--- a/Configuration/TypoScript/Library/lib.content.stdheader.setupts
+++ b/Configuration/TypoScript/Library/lib.content.stdheader.setupts
@@ -1,51 +1,60 @@
 lib.stdheader {
-	3.headerClass.cObject {
+	3.headerClass.cObject.stdWrap {
         20.value = first-child
-        stdWrap {
-            noTrimWrap = |
-            required >
-        }
-    }
-    10 {
-        key.ifEmpty >
-        default = TEXT
-        default {
-            current = 1
-            dataWrap = <h2 class="headline text-color {register:headerClass}"><span class="border-color">|</span></h2>
-        }
-        1 = TEXT
-        1 {
-            current = 1
-            dataWrap = <h3 class="primary-font {register:headerClass}">|</h3>
-
-        }
+		noTrimWrap = |
+		// class="hl |"|
+		required >
+	}
+	10 {
+		key.ifEmpty >
+		default = TEXT
+		default {
+			current = 1
+            dataWrap = <h2 class="headline top-zero text-color {register:headerClass}"><span class="border-color">|</span></h2>
+		}
         2 = TEXT
         2 {
             current = 1
-            dataWrap = <h4 class="primary-font {register:headerClass}">|</h4>
+            dataWrap = <h2 class="text-color {register:headerClass}">|</h2>
         }
         3 = TEXT
         3 {
             current = 1
-            dataWrap = <h4 class="primary-font {register:headerClass}">|</h4>
+            dataWrap = <h3 class="primary-font {register:headerClass}">|</h3>
         }
         4 = TEXT
         4 {
             current = 1
-            dataWrap = <h2 class="text-color {register:headerClass}">|</h2>
+            dataWrap = <h4 class="primary-font {register:headerClass}">|</h4>
         }
-        5 = TEXT
-        5 {
+		6 = TEXT
+		6 {
+			current = 1
+			dataWrap = <div class="block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div>
+		}
+
+		7 = TEXT
+		7 {
+			current = 1
+			dataWrap = <div class="row"><div class="col-md-12 block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div></div>
+		}
+        8 = TEXT
+        8 {
             current = 1
             dataWrap = <h3 class="headline text-color {register:headerClass}"><span class="border-color">|</span></h3>
         }
-        6 = TEXT
-        6 {
+        1001 = TEXT
+        1001 {
             current = 1
             dataWrap = <h1 class="animated fadeInDown {register:headerClass}">|</h1>
         }
-		7 = TEXT
-		7 {
+        1002 = TEXT
+        1002 {
+            current = 1
+            dataWrap = <h1 class="animated fadeInUp {register:headerClass}">|</h1>
+        }
+		1003 = TEXT
+		1003 {
 			current = 1
 			split{
 				token = |
@@ -61,7 +70,47 @@ lib.stdheader {
 			}
 			dataWrap = <h1 class="animated slideInLeft {register:headerClass}">|</h1>
 		}
+		1004 = TEXT
+		1004 {
+			current = 1
+			split{
+				token = |
+				cObjNum = 1||2
+				1{
+					current = 1
+					wrap = |</br>
+				}
+				2{
+					current = 1
+					wrap = |
+				}
+			}
+			dataWrap = <h1 class="animated slideInRight {register:headerClass}">|</h1>
+		}
+		2001 = TEXT
+		2001 {
+			current = 1
+			dataWrap = <div class="block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div>
+		}
+
+		2002 = TEXT
+		2002 {
+			current = 1
+			dataWrap = <div class="row"><div class="col-md-12 block-header"><h2{register:headerClass}><span class="title">|</span><span class="decoration"></span><span class="decoration"></span><span class="decoration"></span></h2></div></div>
+		}
+
+
+	}
+	20 {
+		1.wrap = <h2 class="hl">|</h2>
+		2.wrap = <h3 class="hl">|</h3>
+		3.wrap = <h4 class="hl">|</h4>
+		4.wrap = <h5 class="hl">|</h5>
+		5.wrap = <h6 class="hl">|</h6>
+		default.wrap = <h3 class="hl">|</h3>
+	}
+	stdWrap {
+		dataWrap = <div class="csc-header csc-header-n{cObj:parentRecordNumber}">|</div>
+		dataWrap.override = <header class="csc-header csc-header-n{cObj:parentRecordNumber}">|</header>
 	}
 }
-
-lib.stdheader.10.setCurrent.prepend.noTrimWrap = |<i class="| fa-2x text-color" aria-hidden="true"></i> |


### PR DESCRIPTION
Adjusted Header settings for Layout 1 - Layout 5 to make them kompatible with other templates

I left the special h# settings of mosaic

The special items like special H1 settings with jquery animations I moved to 1001 
The H2 settings fo highland to 2001 (as example how a structure could be used)

I would suggest to add the jquery animation stuff to the CE Header itself i.e. using a drop down box or dropdown boxes you can choose the kind of animation and i.e. other dropdown boxes to choose some settings for the animation. This way all kind of headers could be animated and it won't be necessary to add different animations to the Header Layout List

It needs cleanup! as I left old settings and deactivated them.

I have set the Naming to default Naming Layout 1 - Layout 5
a more comprehensive Naming for Editors would be the one which is deactivated right now.
H1 ... - H5 ....
